### PR TITLE
Update kustomization.yaml

### DIFF
--- a/manifests/overlays/e2e/kustomization.yaml
+++ b/manifests/overlays/e2e/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: networkop/meshnet
+- name: h-fam/meshnet
   newTag: 6e97bf0-dirty
 resources:
 - ../../base/


### PR DESCRIPTION
it should be possible to install the meshnet-cni as `kubectl apply -k raw.github.../e2e/kustomization.yaml` as an alternative to cloning the repo and doing `kubectl apply -f manifests/base` 